### PR TITLE
feat-windows-registry-obsidian-launch

### DIFF
--- a/src/build.bat
+++ b/src/build.bat
@@ -7,10 +7,10 @@ REM 设置项目根目录变量，指向src的上级目录（即项目根目录�
 set ROOTDIR=%~dp0..\
 
 REM 检查 pyinstaller 是否已安装，若未安装则自动安装并重启脚本
-where pyinstaller >nul 2>nul
+py -m PyInstaller --version >nul 2>nul
 if %errorlevel% neq 0 (
     echo 未检测到 pyinstaller，正在安装...
-    pip install pyinstaller
+    py -m pip install pyinstaller
     echo pyinstaller 安装完成，正在重启打包脚本...
     "%~f0"
     exit /b
@@ -31,7 +31,7 @@ REM --icon：指定exe图标
 REM --distpath：输出目录
 REM --workpath：临时工作目录
 REM --specpath：spec文件目录
-call pyinstaller --onefile --windowed --name obsidian-pure-launcher --icon %ROOTDIR%assets\app-icon.ico --distpath %ROOTDIR%dist --workpath %ROOTDIR%build --specpath %ROOTDIR%build main.py
+py -m PyInstaller --onefile --windowed --name obsidian-pure-launcher --icon %ROOTDIR%assets\app-icon.ico --distpath %ROOTDIR%dist --workpath %ROOTDIR%build --specpath %ROOTDIR%build main.py
 
 REM 清理build中间文件夹，dist目录和exe保留
 if exist %ROOTDIR%build rmdir /s /q %ROOTDIR%build

--- a/src/main.py
+++ b/src/main.py
@@ -1,28 +1,48 @@
 # 导入os包
 import os
 import subprocess
+from registry_utils import get_enhanced_obsidian_paths
 
 # 替换obsidian.json中的冗余字符串
-with open(os.getenv("APPDATA") + '\obsidian\obsidian.json', 'r', encoding="utf-8") as file:
-    content = file.read()
-replaced_content = content.replace(',"open":true', '')
-with open(os.getenv("APPDATA") + '\obsidian\obsidian.json', 'w', encoding="utf-8") as file:
-    file.write(replaced_content)
+try:
+    obsidian_config_path = os.path.join(os.getenv("APPDATA"), 'obsidian', 'obsidian.json')
+    if os.path.exists(obsidian_config_path):
+        with open(obsidian_config_path, 'r', encoding="utf-8") as file:
+            content = file.read()
+        replaced_content = content.replace(',"open":true', '')
+        with open(obsidian_config_path, 'w', encoding="utf-8") as file:
+            file.write(replaced_content)
+        print("[成功] 配置文件已修改")
+    else:
+        print("[警告] 未找到obsidian.json配置文件")
+except Exception as e:
+    print(f"[错误] 修改配置文件失败: {e}")
 
-# 启动obsidian
-# os.system('start C:\\Users\\' + os.getlogin() + '\\AppData\\Local\\Obsidian\\Obsidian.exe')
-# os.system(r'start "" "C:\Program Files\Obsidian\Obsidian.exe"')
+# 启动obsidian - 使用增强的路径查找
+print("\n检查Obsidian安装路径...")
+print("=" * 40)
 
-OBSIDIAN_PATHS = [
-    fr'C:\Users\{os.getlogin()}\AppData\Local\Obsidian\Obsidian.exe',
-    r'C:\Program Files\Obsidian\Obsidian.exe'
-]
+# 使用注册表增强的路径查找
+OBSIDIAN_PATHS = get_enhanced_obsidian_paths()
 
-for path in OBSIDIAN_PATHS:
+path_found = False
+for i, path in enumerate(OBSIDIAN_PATHS, 1):
+    print(f"正在检查路径 {i}: {path}")
     if os.path.exists(path):
-        # os.system(f'start "" "{path}"')
+        print(f"[成功找到] {path}")
+        print("即将启动Obsidian...")
         subprocess.Popen([path], shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        print("启动命令已执行")
+        path_found = True
         break
+    else:
+        print(f"[未找到] {path}")
+    print()
+
+if not path_found:
+    print("所有路径都未找到Obsidian")
+    print("请检查Obsidian是否已正确安装")
 else:
-    # print("Obsidian 未找到，请检查安装路径。")
-    pass  # 可加提示或日志
+    print("\n" + "=" * 40)
+    print("成功启动Obsidian！")
+    print("=" * 40)

--- a/src/registry_utils.py
+++ b/src/registry_utils.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""
+注册表工具模块
+用于查询Windows注册表信息
+"""
+import winreg
+import os
+
+def get_program_files_paths():
+    """
+    从注册表获取Program Files相关路径
+    返回包含各种Program Files路径的字典
+    """
+    paths = {}
+    
+    try:
+        # 打开注册表键
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, 
+                            r"SOFTWARE\Microsoft\Windows\CurrentVersion")
+        
+        # 查询Program Files目录
+        try:
+            program_files_dir, _ = winreg.QueryValueEx(key, "ProgramFilesDir")
+            paths["ProgramFilesDir"] = program_files_dir
+            print(f"Program Files目录: {program_files_dir}")
+        except FileNotFoundError:
+            paths["ProgramFilesDir"] = None
+            print("未找到ProgramFilesDir")
+        
+        # 查询Program Files (x86)目录
+        try:
+            program_files_x86, _ = winreg.QueryValueEx(key, "ProgramFilesDir (x86)")
+            paths["ProgramFilesDirX86"] = program_files_x86
+            print(f"Program Files (x86)目录: {program_files_x86}")
+        except FileNotFoundError:
+            paths["ProgramFilesDirX86"] = None
+            print("未找到ProgramFilesDir (x86)")
+        
+        # 查询Program W6432目录
+        try:
+            program_w6432, _ = winreg.QueryValueEx(key, "ProgramW6432Dir")
+            paths["ProgramW6432Dir"] = program_w6432
+            print(f"Program W6432目录: {program_w6432}")
+        except FileNotFoundError:
+            paths["ProgramW6432Dir"] = None
+            print("未找到ProgramW6432Dir")
+        
+        # 关闭键
+        winreg.CloseKey(key)
+        
+    except Exception as e:
+        print(f"读取注册表时出错: {e}")
+        # 使用默认路径作为后备
+        paths = {
+            "ProgramFilesDir": r"C:\Program Files",
+            "ProgramFilesDirX86": r"C:\Program Files (x86)",
+            "ProgramW6432Dir": r"C:\Program Files"
+        }
+    
+    return paths
+
+def find_obsidian_in_registry():
+    """
+    从注册表中查找Obsidian的安装路径
+    """
+    possible_keys = [
+        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+        (winreg.HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"),
+    ]
+    
+    for hkey, subkey in possible_keys:
+        try:
+            with winreg.OpenKey(hkey, subkey) as key:
+                i = 0
+                while True:
+                    try:
+                        subkey_name = winreg.EnumKey(key, i)
+                        with winreg.OpenKey(key, subkey_name) as app_key:
+                            try:
+                                display_name, _ = winreg.QueryValueEx(app_key, "DisplayName")
+                                if "Obsidian" in display_name:
+                                    try:
+                                        install_location, _ = winreg.QueryValueEx(app_key, "InstallLocation")
+                                        exe_path = os.path.join(install_location, "Obsidian.exe")
+                                        if os.path.exists(exe_path):
+                                            print(f"从注册表找到Obsidian: {exe_path}")
+                                            return exe_path
+                                    except FileNotFoundError:
+                                        # 尝试从DisplayIcon获取路径
+                                        try:
+                                            icon_path, _ = winreg.QueryValueEx(app_key, "DisplayIcon")
+                                            if icon_path.endswith("Obsidian.exe"):
+                                                if os.path.exists(icon_path):
+                                                    print(f"从注册表图标路径找到Obsidian: {icon_path}")
+                                                    return icon_path
+                                        except FileNotFoundError:
+                                            pass
+                            except FileNotFoundError:
+                                pass
+                        i += 1
+                    except OSError:
+                        break
+        except Exception as e:
+            continue
+    
+    print("未在注册表中找到Obsidian")
+    return None
+
+def get_enhanced_obsidian_paths():
+    """
+    获取增强的Obsidian路径列表，结合注册表查询和常规路径
+    """
+    paths = []
+    
+    # 首先尝试从注册表获取
+    registry_path = find_obsidian_in_registry()
+    if registry_path:
+        paths.append(registry_path)
+    
+    # 获取Program Files路径
+    program_paths = get_program_files_paths()
+    
+    # 添加常规路径
+    common_paths = [
+        fr'C:\Users\{os.getlogin()}\AppData\Local\Obsidian\Obsidian.exe',
+    ]
+    
+    # 添加Program Files相关路径
+    for key, program_dir in program_paths.items():
+        if program_dir:
+            obsidian_path = os.path.join(program_dir, "Obsidian", "Obsidian.exe")
+            common_paths.append(obsidian_path)
+    
+    # 合并路径并去重
+    paths.extend(common_paths)
+    unique_paths = []
+    for path in paths:
+        if path not in unique_paths:
+            unique_paths.append(path)
+    
+    return unique_paths
+
+if __name__ == "__main__":
+    print("=" * 50)
+    print("注册表查询测试")
+    print("=" * 50)
+    
+    # 测试获取Program Files路径
+    print("\n1. 获取Program Files路径:")
+    paths = get_program_files_paths()
+    
+    # 测试查找Obsidian
+    print("\n2. 查找Obsidian安装路径:")
+    obsidian_paths = get_enhanced_obsidian_paths()
+    
+    print(f"\n找到 {len(obsidian_paths)} 个可能的Obsidian路径:")
+    for i, path in enumerate(obsidian_paths, 1):
+        exists = "✓" if os.path.exists(path) else "✗"
+        print(f"{i}. {exists} {path}")

--- a/start_obsidian.bat
+++ b/start_obsidian.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal enabledelayedexpansion
+chcp 65001 >nul 2>&1
+
+REM 修改Obsidian配置文件
+set obsidianJsonPath=%APPDATA%\obsidian\obsidian.json
+if exist "%obsidianJsonPath%" (
+    powershell -Command "& {try { $content = Get-Content '%obsidianJsonPath%' -Raw -Encoding UTF8; $newContent = $content -replace ',\"open\":true', ''; $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False; [System.IO.File]::WriteAllText('%obsidianJsonPath%', $newContent, $Utf8NoBomEncoding) } catch { }}" >nul 2>&1
+)
+
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion" /v ProgramFilesDir 2^>nul') do (
+  set ProgramFilesPath=%%b
+)
+
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion" /v "ProgramFilesDir (x86)" 2^>nul') do (
+  set ProgramFiles86Path=%%b
+)
+
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion" /v "ProgramW6432Dir" 2^>nul') do (
+  set ProgramW6432Dir=%%b
+)
+
+for %%i in (
+    "%LOCALAPPDATA%\Obsidian\Obsidian.exe"
+    "%ProgramFilesPath%\Obsidian\Obsidian.exe"
+    "%ProgramFiles86Path%\Obsidian\Obsidian.exe"
+    "%ProgramW6432Dir%\Obsidian\Obsidian.exe"
+) do (
+    if exist "%%~i" (
+        start "" "%%~i"
+        goto end
+    )
+)
+
+where obsidian.exe >nul 2>&1
+if not errorlevel 1 (
+    start "" obsidian.exe
+)
+
+:end

--- a/start_obsidian_console.bat
+++ b/start_obsidian_console.bat
@@ -1,0 +1,81 @@
+@echo off
+setlocal enabledelayedexpansion
+chcp 65001 >nul
+
+echo ==========================================
+echo Obsidian启动脚本
+echo ==========================================
+echo.
+
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion" /v ProgramFilesDir') do (
+  set ProgramFilesPath=%%b
+)
+echo 默认Program Files目录: %ProgramFilesPath%
+
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion" /v "ProgramFilesDir (x86)"') do (
+  set ProgramFiles86Path=%%b
+)
+echo 默认Program Files (x86)目录: %ProgramFiles86Path%
+
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion" /v "ProgramW6432Dir"') do (
+  set ProgramW6432Dir=%%b
+)
+echo 默认Program W6432目录: %ProgramW6432Dir%
+
+echo.
+echo 第三步：修改Obsidian配置文件
+echo ==========================================
+
+set obsidianJsonPath=%APPDATA%\obsidian\obsidian.json
+echo 检查配置文件: %obsidianJsonPath%
+
+if exist "%obsidianJsonPath%" (
+    echo [找到配置文件] 正在修改obsidian.json...
+    
+    REM 直接使用PowerShell修改文件，删除 ,"open":true
+    powershell -Command "& {try { $content = Get-Content '%obsidianJsonPath%' -Raw -Encoding UTF8; $newContent = $content -replace ',\"open\":true', ''; $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False; [System.IO.File]::WriteAllText('%obsidianJsonPath%', $newContent, $Utf8NoBomEncoding); Write-Host '[成功] 配置文件已修改' } catch { Write-Host '[错误] 修改配置文件失败:' $_.Exception.Message }}"
+) else (
+    echo [警告] 未找到obsidian.json配置文件
+)
+
+echo.
+echo 第四步：检查Obsidian安装路径
+echo ==========================================
+
+set pathCount=0
+for %%i in (
+    "%LOCALAPPDATA%\Obsidian\Obsidian.exe"
+    "%ProgramFilesPath%\Obsidian\Obsidian.exe"
+    "%ProgramFiles86Path%\Obsidian\Obsidian.exe"
+    "%ProgramW6432Dir%\Obsidian\Obsidian.exe"
+) do (
+    set /a pathCount+=1
+    echo 正在检查路径 !pathCount!: %%~i
+    if exist "%%~i" (
+        echo [成功找到] %%~i
+        echo 即将启动Obsidian...
+        start "" "%%~i"
+        echo 启动命令已执行
+        goto success
+    ) else (
+        echo [未找到] %%~i
+    )
+    echo.
+)
+
+echo.
+echo 所有路径都未找到Obsidian
+goto end
+
+:success
+echo.
+echo ==========================================
+echo 成功启动Obsidian！
+echo ==========================================
+
+:end
+echo.
+echo ==========================================
+echo 脚本执行完毕
+echo ==========================================
+pause >nul


### PR DESCRIPTION
- 新增registry_utils.py，实现从Windows注册表获取Program Files路径及Obsidian安装路径，提升系统环境适应性  
- 修改build.bat，使用py -m方式调用PyInstaller，自动安装缺失的pyinstaller并重启脚本，简化打包流程  
- 添加start_obsidian_console.bat脚本，自动检测Obsidian安装路径（支持多路径查找）并启动  
- 自动修改obsidian.json配置，移除"open":true字段，避免自动打开  
- 启动时自动选择第一个存在的可执行文件路径，增加启动日志输出，统一UTF-8编码，提升启动流程自动化和用户体验